### PR TITLE
Return files on API as a kind of posts

### DIFF
--- a/lib/carraway/file.rb
+++ b/lib/carraway/file.rb
@@ -3,15 +3,16 @@ require 'aws-sdk-s3'
 
 module Carraway
   class File
-    attr_reader :uid, :created, :file
+    attr_reader :uid, :created, :file, :published
     attr_accessor :title, :labels
 
-    def initialize(title:, file: nil, uid: nil, created: nil, labels: nil)
+    def initialize(title:, file: nil, uid: nil, created: Time.now.to_i, labels: nil, published: nil)
       @title = title
       @file = file
       @uid = uid || generate_uid
       @created = created
       @labels = labels
+      @published = published || created
     end
 
     %i(created).each do |col|
@@ -25,6 +26,18 @@ module Carraway
       ext = '.pdf' # FIXME Accept other type
       # Seems prefix does not have to required parameter
       [Config.file_backend['prefix'], '/', @uid, ext].join
+    end
+
+    def to_h
+      {
+        uid: @uid,
+        title: @title,
+        path: path,
+        labels: @labels,
+        record_type: 'file',
+        created: @created.to_i,
+        published: @published && @published.to_i
+      }
     end
 
     private

--- a/lib/carraway/file_repository.rb
+++ b/lib/carraway/file_repository.rb
@@ -14,7 +14,8 @@ module Carraway
           uid: item['uid'],
           title: item['title'],
           created: item['created'],
-          labels: item['labels']
+          labels: item['labels'],
+          published: item['published']
         )
       end
     end
@@ -31,7 +32,8 @@ module Carraway
           uid: item['uid'],
           title: item['title'],
           created: item['created'],
-          labels: item['labels']
+          labels: item['labels'],
+          published: item['published']
         )
       end
     end
@@ -54,7 +56,8 @@ module Carraway
           record_type: 'file',
           title: file.title,
           created: file.created || at.to_i,
-          labels: file.labels
+          labels: file.labels,
+          published: file.published
         }
       )
       if file.file

--- a/lib/carraway/server.rb
+++ b/lib/carraway/server.rb
@@ -25,7 +25,7 @@ module Carraway
     end
 
     get '/carraway/api/posts' do
-      posts = Post.all(published_only: true).map(&:to_h)
+      posts = Post.all(published_only: true, include_file: true).map(&:to_h)
 
       # HACK Expand plugin
       transformed = params[:view] == 'html'

--- a/spec/carraway/post_spec.rb
+++ b/spec/carraway/post_spec.rb
@@ -75,6 +75,72 @@ RSpec.describe Carraway::Post do
     end
   end
 
+  describe '.all' do
+    let!(:published_post) do
+      described_class.create(
+        title: 'Published post',
+        body: 'This is an article.',
+        category_key: 'test_category',
+        published: Time.now.to_i - 1
+      )
+    end
+
+    let!(:unpublished_post) do
+      described_class.create(
+        title: 'Unpublished post',
+        body: 'This is an article.',
+        category_key: 'test_category',
+      )
+    end
+    let(:file) do
+      Carraway::File.new(
+        title: 'File Title',
+        file: { tempfile: '' },
+        published: Time.now.to_i - 1
+      )
+    end
+
+    before do
+      Carraway::FileRepository.new.save(file)
+    end
+
+    it 'returns all posts' do
+      post_uids = described_class.all.map(&:uid)
+
+      expect(post_uids.size).to eq(2)
+      expect(post_uids).to be_include(published_post.uid)
+      expect(post_uids).to be_include(unpublished_post.uid)
+      expect(post_uids).to_not be_include(file.uid)
+    end
+
+    it 'returns published posts with published_only' do
+      post_uids = described_class.all(published_only: true).map(&:uid)
+
+      expect(post_uids.size).to eq(1)
+      expect(post_uids).to be_include(published_post.uid)
+      expect(post_uids).to_not be_include(unpublished_post.uid)
+      expect(post_uids).to_not be_include(file.uid)
+    end
+
+    it 'returns posts and files with include_file' do
+      post_uids = described_class.all(include_file: true).map(&:uid)
+
+      expect(post_uids.size).to eq(3)
+      expect(post_uids).to be_include(published_post.uid)
+      expect(post_uids).to be_include(unpublished_post.uid)
+      expect(post_uids).to be_include(file.uid)
+    end
+
+    it 'returns published posts and files with include_file and published_only' do
+      post_uids = described_class.all(include_file: true, published_only: true).map(&:uid)
+
+      expect(post_uids.size).to eq(2)
+      expect(post_uids).to be_include(published_post.uid)
+      expect(post_uids).to_not be_include(unpublished_post.uid)
+      expect(post_uids).to be_include(file.uid)
+    end
+  end
+
   describe '#path' do
     let(:post) do
       described_class.create(


### PR DESCRIPTION
**!!!This change includes breaking changes!!!**

# Goal
Current carraway supports only pdf files. This change makes carraway to return files as a kind of posts, so that Gatsby can list files as a isolated page.

# Breaking changes
- API includes posts and files(current version includes only posts)
- File has `published` attributes. This value is same with `created`.
- Files saved by old version carraway do not have `published` value, so they will not be appear in API response. If you want to include these old records, you have to re-save files on carraway. (carraway automatically sets `published` on save)

I will release v1.0.0 after merge this.