### PR TITLE
Ignore nil body to support file

### DIFF
--- a/lib/carraway/server.rb
+++ b/lib/carraway/server.rb
@@ -30,7 +30,10 @@ module Carraway
       transformed = params[:view] == 'html'
       if transformed
         markdown = Redcarpet::Markdown.new(Redcarpet::Render::HTML)
-        posts = posts.map { |post| post[:body] = markdown.render(post[:body]); post }
+        posts = posts.map do |post|
+          post[:body] = markdown.render(post[:body]) if post[:body]
+          post
+        end
       end
 
       { data: { posts: posts } }.to_json

--- a/spec/carraway/server_spec.rb
+++ b/spec/carraway/server_spec.rb
@@ -105,7 +105,7 @@ RSpec.describe Carraway::Server, type: :request do
         json = JSON.parse(last_response.body)
 
         expect(json['data']['posts'].size).to eq(2)
-        post_response = json['data']['posts'].first
+        post_response = json['data']['posts'].detect {|post| post['record_type'] == 'post'}
         expect(post_response['title']).to eq(post.title)
         expect(post_response['body']).to eq(<<~BODY)
         <h1>Header</h1>

--- a/spec/carraway/server_spec.rb
+++ b/spec/carraway/server_spec.rb
@@ -98,17 +98,13 @@ RSpec.describe Carraway::Server, type: :request do
     end
 
     context 'if html view option is given' do
-      before do
-        file_repository.destroy(file)
-      end
-
       it 'returns published posts' do
         get '/carraway/api/posts?view=html'
         expect(last_response).to be_ok
 
         json = JSON.parse(last_response.body)
 
-        expect(json['data']['posts'].size).to eq(1)
+        expect(json['data']['posts'].size).to eq(2)
         post_response = json['data']['posts'].first
         expect(post_response['title']).to eq(post.title)
         expect(post_response['body']).to eq(<<~BODY)


### PR DESCRIPTION
Fixed the following error because I want to use record_type: 'file'.

```
$ curl http://localhost:5000/carraway/api/posts?view=html
TypeError: wrong argument type nil (expected String)
	XXXX/carraway-1.0.0/lib/carraway/server.rb:33:in `render'
```